### PR TITLE
Add GitLab CI Pipeline for PHP Application

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,97 @@
+variables:
+  DOCKER_REGISTRY: "localhost:5000"
+  APP_NAME: "myapp"
+  Sonar_Url: "https://localhost"
+  Sonar_Token: "sonarqube"
+  security_scan_tool: "trivy"
+  GIT_SHA: "$(git rev-parse --short HEAD)"
+
+stages:
+  - checkout
+  - install_dependencies
+  - build
+  - unit_test
+  - static_code_analysis
+  - quality_gate
+  - docker_build_push
+  - security_scan
+  - deploy
+
+checkout:
+  stage: checkout
+  script:
+    - echo "Checking out source code"
+    - git clone $CI_REPOSITORY_URL .
+
+install_dependencies:
+  stage: install_dependencies
+  script:
+    - echo "Installing dependencies"
+    - composer install
+
+build:
+  stage: build
+  script:
+    - echo "Building the application"
+    - php -l index.php
+
+unit_test:
+  stage: unit_test
+  script:
+    - echo "Running unit tests"
+    - ./vendor/bin/phpunit tests
+
+static_code_analysis:
+  stage: static_code_analysis
+  script:
+    - echo "Performing static code analysis"
+    - sonar-scanner -Dsonar.host.url=$Sonar_Url -Dsonar.login=$Sonar_Token
+
+quality_gate:
+  stage: quality_gate
+  script:
+    - echo "Checking quality gate"
+    - |
+      status=$(curl -s -u $Sonar_Token: "$Sonar_Url/api/qualitygates/project_status?projectKey=$APP_NAME" | jq -r .projectStatus.status)
+      if [[ "$status" != "OK" && "$status" != "NONE" ]]; then
+        echo "Quality Gate failed with status: $status"
+        exit 1
+      fi
+
+docker_build_push:
+  stage: docker_build_push
+  script:
+    - echo "Building and pushing Docker image"
+    - docker build -t $DOCKER_REGISTRY/$APP_NAME:$GIT_SHA .
+    - docker push $DOCKER_REGISTRY/$APP_NAME:$GIT_SHA
+
+security_scan:
+  stage: security_scan
+  script:
+    - echo "Running security scan"
+    - trivy image $DOCKER_REGISTRY/$APP_NAME:$GIT_SHA
+
+deploy:
+  stage: deploy
+  script:
+    - echo "Deploying application"
+    - |
+      if [ -f "helm/values.yaml" ]; then
+        helm upgrade --install $APP_NAME helm/ --set image.repository=$DOCKER_REGISTRY/$APP_NAME,image.tag=$GIT_SHA
+      elif [ -f "deployment.yaml" ]; then
+        case "$(uname -s)" in
+          Darwin*) sed -i '' "s|image: .*$|image: $DOCKER_REGISTRY/$APP_NAME:$GIT_SHA|" deployment.yaml ;;
+          *) sed -i "s|image: .*$|image: $DOCKER_REGISTRY/$APP_NAME:$GIT_SHA|" deployment.yaml ;;
+        esac
+        kubectl apply -f deployment.yaml
+      else
+        echo "No deployment configuration found"
+        exit 1
+      fi
+    - echo "Deployment completed"
+    - echo "Adding rollback mechanism"
+    - |
+      if [ $? -ne 0 ]; then
+        echo "Deployment failed, rolling back"
+        kubectl rollout undo deployment/$APP_NAME
+      fi


### PR DESCRIPTION
This pull request introduces a `.gitlab-ci.yml` file to set up a CI/CD pipeline for the PHP application. The pipeline includes the following stages:

- **Checkout**: Clones the repository.
- **Install Dependencies**: Installs PHP dependencies using Composer.
- **Build**: Validates the PHP application.
- **Unit Test**: Runs PHPUnit tests.
- **Static Code Analysis**: Performs static code analysis using SonarQube.
- **Quality Gate**: Ensures the quality gate is passed before proceeding.
- **Docker Build and Push**: Builds and pushes the Docker image to the local registry.
- **Security Scan**: Scans the Docker image for vulnerabilities using Trivy.
- **Deploy**: Deploys the application using Helm or Kubernetes manifests. Includes a rollback mechanism in case of deployment failure.

closes #1